### PR TITLE
docs: add minor fixes after review

### DIFF
--- a/CONTRIBUTING.template.adoc
+++ b/CONTRIBUTING.template.adoc
@@ -63,11 +63,11 @@ Great, however, there are some practical points to check to make sure that every
 [[code-review]]
 == Issues and Pull Request Feedback
 
-The listed project maintainers (see the link:README.md[README]) of the project are doing their best to review and/or respond to Issues. If the project is not listed as archived, it is maintained.
-You should expect feedback for an Issue or Pull Request in a few days.
+The listed Maintainers (see the link:README.md[README]) of the project are doing their best to review and/or respond to Issues and take responsobility in due time. If the project is not listed as archived, it is maintained.
+You should expect feedback from the Maintainers in a few days.
 
-NOTE: For non trivial and proposed bigger contributions, please discuss the contribution with the project first. 
-There might be occasions where the cost of maintainance and review have to be agreed upon before it can be merged and reviewed.
+NOTE: For non trivial and planned "big" contributions, please discuss the contribution with the project first. 
+There might be occasions where the cost of maintainance and contribution review have to be agreed upon before it can be merged and reviewed.
 
 [[pull-request]]
 == Pull Request Lifecycle
@@ -125,9 +125,10 @@ For newer versions you can use SSH for signing https://github.blog/changelog/202
 
 Aim for a clear human readable commit history:
 
+* **_First - does the project have a defined commit message practice, please follow that_**. 
 * Make sure you link:#dco-signoff-and-signing-a-commitsign-off[Sign-Off] your commits.
 * In general
-    ** Use the https://www.conventionalcommits.org[Conventional Commit standard].
+    ** If the project does not have standard for commits, you might want to consider https://www.conventionalcommits.org[Conventional Commit standard].
     ** Group relevant changes in commits, avoid scope creep and keep focus on the relevant issue.
     ** Your commit messages should tell a human reader what will it do when the commit is applied.
     ** Make your commit message/s easily human readable in a expected way: +
@@ -140,7 +141,7 @@ Aim for a clear human readable commit history:
 
 If you discover a security issue, please bring it to our attention.
 
-If the vulnerability is a widely known issue, detected by various Vulnerability Scanning sources it might be okay to file an public Issue.
+If the vulnerability is a widely known issuee, detected by various Vulnerability Scanning sources it might be okay to file an public Issue.
 
 However, if any uncertainty around this, please **DO NOT** file a public issue, see link:SECURITY.md[Security information] for how to handle this. 
 

--- a/README.md
+++ b/README.md
@@ -13,13 +13,16 @@ This a template project containing 'Community Health Files' and Checklists.
 It's intention is to be a practical helper when releasing a project as Open Source.
 It was created in a general way to be usable for anyone, and proposes well know conventions and de-facto standards when possible.
 
-You are supposed to adjust contents and suggestion to suit your project needs.
+You _are supposed_ to adjust the contents and suggestions to suit your project needs.
 
 ## Project background
 
-The project originated at Digg, when we needed a practical companion to our [guidelines (see references)](#credits-and-references) for releasing new Open Source projects.
-The material was created in Digg's internal Open Source Guild, (an informal group of different interests in the organisation) who reveiwed and proposed the base material.
+The project originated at Digg, when Digg needed a practical companion to their [Open Source Guidelines (see references)](#credits-and-references) for releasing Open Source projects.
+The intent was, in particular, to fill a practical role of Appendix B _Software documentation_ in the mentioned guidelines.
 
+The initial material was created in Digg's internal Open Source Guild, (an informal group of different interests in the organisation) who reveiwed and proposed the base material.
+
+Seeing it could be of wider usage, we aimed to make it as general we could.
 There were already quite a few variants of these template projects out there, which we used for inspiration.
 
 ---
@@ -28,17 +31,18 @@ There were already quite a few variants of these template projects out there, wh
 
 ### Template Files
 
-An short summary of the template files in the repository, and how you can use them.
+An short summary of the files in the repository, and how you can use them.
+You are always supposed to use the '.template' marked versions of any files if one such exists.
 
-- LICENSE - The LICENSE containing the projects "main" LICENSE, which must be an [OSI approved license](https://en.wikipedia.org/wiki/Open_Source_Initiative). You are not supposed to use the one in this project, add your own.
-- CHANGELOG - Describes the project updates in a standard human readable way. Version: [Keep-a-changelog 1.0](https://keepachangelog.com/en/1.0.0/).
+- LICENSE - The LICENSE containing the projects "main" LICENSE, which must be an [OSI approved license](https://en.wikipedia.org/wiki/Open_Source_Initiative). You are not supposed to use the one in this project - add your own.
+- CHANGELOG - Describes the project updates in a standard human readable way. Version: [Keep-a-changelog 1.1.0](https://keepachangelog.com/en/1.1.0/).
 - CODE_OF_CONDUCT - defines standards for how to engage in a community. Version: [Contributor Covenant 2.1](https://www.contributor-covenant.org).
-- CONTRIBUTING - communicates guidelines for how people can contribute to your project.
+- CONTRIBUTING - the guidelines for how people can contribute to your project.
 - Issue Templates - `bug, feature and pull request templates`. Issue and pull request templates to standardize the information contributors can see when they open issues and pull requests in your repository. Might be specific for GitHub/GitLab and so on.
   - `.github/` - contains GitHub specific versions of bug-, pr, feature-templates.
   - `.github/workflows` - contains GitHub workflows for this project. You will most likely write your own workflows for your project.
 - SECURITY - instructions for how to report a security vulnerabilitity in your project.
-- README.template - a template for creating a good informative readme.
+- README- a template for creating a good informative readme.
 
 ### Other Content
 
@@ -47,11 +51,12 @@ An short summary of the template files in the repository, and how you can use th
 
 ## Usage instructions
 
-1. Copy the files you need into your in-progress project - Start with SECURITY.md, README.template.md, CHANGELOG.template.md, CONTRIBUTING.adoc, CODE_OF_CONDUCT.md and possibly the .github/ISSUE_TEMPLATE and .github/pull_request_template.md.
-2. Add a LICENSE file (do not copy the one in this project), and if needed a [CHANGELOG.md](https://keepachangelog.com/en/1.1.0/).
-3. Go through each of the files and adjust to your needs
+1. Copy the files you need into your in-progress project - Start with SECURITY.template.md, README.template.md, CHANGELOG.template.md, CONTRIBUTING.template.adoc, CODE_OF_CONDUCT.md and possibly the .github/ISSUE_TEMPLATE and .github/pull_request_template.md.
+2. Remove '.template' in the filenames you copied.
+3. Add a LICENSE file (do not copy the one in this project), and if needed a [CHANGELOG.md](https://keepachangelog.com/en/1.1.0/).
+4. Go through each of the files and adjust to your needs
    - Correct any [Template Variables](#template-files-variables) in the Template files.
-4. Answer the questions on the [Open Source Checklist:](Open_Source_Checklist.md)
+5. Answer the questions on the [Open Source Checklist:](Open_Source_Checklist.md)
 
 > Keep the README fresh! It's the first thing people see and will make the initial impression.  
 > Understand the contents of the files you use from this project. Do they fit within your project, or are you looking for something else?  
@@ -67,7 +72,7 @@ In the special case that you git cloned this project and are using it as a proje
 Replace the following variables with if you are using these files.
 
 - CODE_OF_CONDUCT.adoc - Replace `INSERT_CONTACT_METHOD`.
-- SECURITY.md - Replace `INSERT_CONTACT_METHOD` and `INSERT_CONTACT`.
+- SECURITY.template.md - Replace `INSERT_CONTACT_METHOD` and `INSERT_CONTACT`.
 - .github/pull_request_template.md - Replace `INSERT_CONTRIBUTING_LINK`.
 
 ## Contributing
@@ -83,11 +88,12 @@ There are future plans for this template project.
 
 Currently, the project is undergoing a feedback revision from Foundation for Public Code. After that, 0.1.0 will be tagged.
 
-### Future versions
+### Future
 
 - Mention project excellence additions (extras in the checklist?) - OpenSSF scorecard, Foundation for Public Codes metadata standard and so on.
 - Handling GOVERNANCE.md recomendations?
 - Handling DEVELOPMENT.md recommendations?
+- Add CODEOWNERS?
 - Add local linting (currently only in CI-pipeline)
 - Keep the Swedish translations up-to-date
 - Handling where to recommend communication channels for users and developers
@@ -96,15 +102,6 @@ Currently, the project is undergoing a feedback revision from Foundation for Pub
 - Your suggestions
 
 ---
-
-## Standards
-
-This template project aims to follow the standards it propose:
-
-- License compliance with the [REUSE specification](https://reuse.software/) (and with that, [SPDX-declarations](https://spdx.github.io/spdx-spec/v2.3/)using-SPDX-short-identifiers-in-source-files/)
-- Commits in the [Conventional Commits format](https://www.conventionalcommits.org/en/v1.0.0/)
-- Changelog in the [Keep-A-Changelog format](https://keepachangelog.com/en/1.1.0/)
-- Contribution guidelines [Contributor Covenant guidelines](https://www.contributor-covenant.org/)
 
 ## License
 
@@ -121,7 +118,11 @@ License: [CC-BY-4.0](https://creativecommons.org/licenses/by/4.0/)
 
 ## Maintainers
 
-asom/Digg Open Source Guild
+Governance of the project is currently handled by the collaboration of:
+
+asom (arbetsgruppen för samordning av mjukvara) and Digg's Open Source Guild
+
+It will be further clearified in the future (see [future versions](#roadmap))
 
 ## Credits and References
 
@@ -130,3 +131,7 @@ asom/Digg Open Source Guild
 - [IEEE Open Source Maintainers Manual](https://opensource.ieee.org/community/manual/)
 - [Foundation for Public Code](https://publiccode.net/)
 - [Digg's internal policy and guidance document regarding Open Source](https://www.digg.se/analys-och-uppfoljning/publikationer/publikationer/2022-09-27-anskaffning-utveckling-och-publicering-av-oppen-programvara-policy-och-riktlinjer)
+
+## Public known users of this template
+
+- [Jitsi Outlook Plugin](https://github.com/diggsweden/jitsi-outlook)

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,9 +1,3 @@
-<!--
-SPDX-FileCopyrightText: 2023 Digg - Agency for Digital Government
-
-SPDX-License-Identifier: CC0-1.0
--->
-
 # Security Reporting
 
 If you wish to report a security vulnerability but not in a public issue -- thank you!
@@ -15,12 +9,35 @@ Please report security vulnerabilities by filling out the following template:
 - PUBLIC: Please let us know if this vulnerability has been made or discussed publicly already, and if so, please let us know where.
 - DESCRIPTION: Please provide precise description of the security vulnerability you have found with as much information as you are able and willing to provide.
 
-Please send the above info, along with any other information you feel is pertinent to: [INSERT_CONTACT_METHOD].
+Please send the above info, along with any other information you feel is pertinent to: ospo AT digg.se.
 
 Vulnerabilities reported will be handled on a best effort basis.
 
 In addition, you may request that the project provide you a patched release in advance of the release announcement, however, we can not guarantee that such information will be provided to you in advance of the public release and announcement.
 
-However, [INSERT_CONTACT] will email you at the same time the public announcement is made.
+However, ospo AT digg.se will email you at the same time the public announcement is made.
 We will let you know within a few weeks whether or not your report has been accepted or rejected.
 We ask that you please keep the report confidential until we have made a public announcement.
+
+---
+
+# Säkerhetsrapport
+
+Om du vill rapportera en sårbarhet, men inte i ett offentligt ärende - tack!
+Vi ber dig att följa följande process.
+
+Vänligen rapportera säkerhetsbrister genom att meddela oss:
+
+- PROJEKT: En URL till projektets arkiv
+- OFFENTLIG SÅRBARHET: Meddela oss gärna i det fall du vet om denna sårbarhet har spridits eller diskuterats offentligt.
+- BESKRIVNING: Ange en beskrivning av sårbarheten du har hittat, med så mycket information som du kan (och vill) tillhandahålla.
+
+Skicka ovanstående information tillsammans med övrig information som du anser är relevant för: ospo AT digg.se.
+
+Rapporter hanteras efter bästa förmåga.
+
+Dessutom kan du begära att projektet ger dig en korrigerad version innan releasemeddelandet, men vi kan inte garantera att sådan information kommer att tillhandahållas till dig innan den offentliga releasen och tillkännagivandet.
+
+ospo AT digg.se kommer dock att skicka ett e-postmeddelande till dig samtidigt som det offentliga meddelandet görs.
+Vi kommer att meddela dig inom några veckor om din anmälan har godkänts eller avvisats.
+Vi ber dig att hålla rapporten konfidentiell tills vi har gjort ett offentligt tillkännagivande.

--- a/SECURITY.template.md
+++ b/SECURITY.template.md
@@ -1,0 +1,26 @@
+<!--
+SPDX-FileCopyrightText: 2023 Digg - Agency for Digital Government
+
+SPDX-License-Identifier: CC0-1.0
+-->
+
+# Security Reporting
+
+If you wish to report a security vulnerability but not in a public issue -- thank you!
+We ask that you follow the following process.
+
+Please report security vulnerabilities by filling out the following template:
+
+- PROJECT: A URL to project's repository
+- PUBLIC: Please let us know if this vulnerability has been made or discussed publicly already, and if so, please let us know where.
+- DESCRIPTION: Please provide precise description of the security vulnerability you have found with as much information as you are able and willing to provide.
+
+Please send the above info, along with any other information you feel is pertinent to: [INSERT_CONTACT_METHOD].
+
+Vulnerabilities reported will be handled on a best effort basis.
+
+In addition, you may request that the project provide you a patched release in advance of the release announcement, however, we can not guarantee that such information will be provided to you in advance of the public release and announcement.
+
+However, [INSERT_CONTACT] will email you at the same time the public announcement is made.
+We will let you know within a few weeks whether or not your report has been accepted or rejected.
+We ask that you please keep the report confidential until we have made a public announcement.


### PR DESCRIPTION
This PR aims to fix a few minor topics after a review from Foundation for Public Code.
It is part of an ongoing process to improve the project.

Aims to fix the following doc content:
- Closer explain the connection to Digg's Internal Open Source Policy and how they are connected. (This project can be seen as a practical appendix from that.
- Adds a "Public known users list"
- Adds a note in Contributing that maintanance and review costs might at times have to be agreed upon, and gives some examples for when that might occur.
- Adds a note about expected response times.

Structure:
- The SECURITY.md template was moved to SECURITY.template.md, and a real SECURITY, based on that for this project was added.
- Same with CONTRIBUTING, a template version was added.
- The Standard moved to the CONTRIBUTING file

## Checklist

- [x] My contributions and commit messages follows the style guidelines of this project
- [x] I have made corresponding changes to the documentation
- [x] The Pull Request has an informative and human-readable title
- [x] Changes are limited to a single goal (avoid scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] I confirm that I have read any Contribution guidelines (CONTRIBUTING)
- [x] I confirm that I wrote and/or have the right to submit the contents of my PR, by agreeing to the _Developer Certificate of Origin_, by adding a 'sign-off' to my commits
