### PR TITLE
Update the Standard for Public Code assessment

### DIFF
--- a/docs/standard-for-public-code-assessment.html
+++ b/docs/standard-for-public-code-assessment.html
@@ -122,7 +122,7 @@ Documenting which source code or policy underpins any specific interaction the g
 
 <h2><a href="https://standard.publiccode.net/criteria/bundle-policy-and-source-code.html">Bundle policy and source code</a></h2>
 
-&#9744;<!-- &#9745; --> criterion met.
+&#9745;<!-- &#9745; --> criterion met.
 
 <table id="bundle-policy-and-source-code" style="width:100%">
 <tr><th>Meets</th><th>Requirement</th><th style="width:25%">Notes and links</th></tr>
@@ -134,7 +134,7 @@ Ok
 The codebase MUST include the policy that the source code is based on.
 </td>
 <td>
-Great with the link to the policy, but the relationship to it is somewhat unclear. It it would be nice to understand how strong connection the template has to the policy.
+
 </td>
 </tr>
 
@@ -214,7 +214,7 @@ The codebase MUST be independent from any secret, undisclosed, proprietary or no
 The codebase SHOULD be in use by multiple parties.
 </td>
 <td>
-
+<a href="https://github.com/diggsweden/open-source-project-template/tree/main#public-known-users-of-this-template">Public known users of this template</a>
 </td>
 </tr>
 
@@ -256,13 +256,13 @@ Configuration SHOULD be used to make source code adapt to context specific needs
 
 <tr>
 <td>
-Ok
+
 </td>
 <td>
 The codebase SHOULD be localizable.
 </td>
 <td>
-
+There is a l10n folder but it is unclear if it is for the policies applying for this codebase or if they are translated template files.
 </td>
 </tr>
 
@@ -348,13 +348,13 @@ The codebase MUST document the governance of the codebase, contributions and its
 
 <tr>
 <td>
-
+Ok
 </td>
 <td>
 The contribution guidelines SHOULD document who is expected to cover the costs of reviewing contributions.
 </td>
 <td>
-
+<a href="https://github.com/diggsweden/open-source-project-template/blob/main/CONTRIBUTING.adoc#issues-and-pull-request-feedback">Issues and Pull Request Feedback</a>
 </td>
 </tr>
 
@@ -446,31 +446,31 @@ Through GitHub
 The codebase MUST have communication channels for users and developers, for example email lists.
 </td>
 <td>
-
+The community forum could be linked from the documentation somewhere.
 </td>
 </tr>
 
 <tr>
 <td>
-
+Ok
 </td>
 <td>
 There MUST be a way to report security issues for responsible disclosure over a closed channel.
 </td>
 <td>
-
+<a href="https://github.com/diggsweden/open-source-project-template/blob/main/SECURITY.md">SECURITY.md</a>
 </td>
 </tr>
 
 <tr>
 <td>
-
+Ok
 </td>
 <td>
 The documentation MUST include instructions for how to report potentially security sensitive issues.
 </td>
 <td>
-
+<a href="https://github.com/diggsweden/open-source-project-template/blob/main/SECURITY.md">SECURITY.md</a>
 </td>
 </tr>
 
@@ -678,7 +678,7 @@ Version control systems SHOULD NOT accept non-reviewed contributions in release 
 Reviews SHOULD happen within two business days.
 </td>
 <td>
-
+"A few days" is mentioned in <a href="https://github.com/diggsweden/open-source-project-template/blob/main/CONTRIBUTING.adoc#issues-and-pull-request-feedback">Issues and Pull Request Feedback</a>, but it is not specific enough.
 </td>
 </tr>
 
@@ -820,25 +820,25 @@ The documentation of the codebase SHOULD contain examples for all functionality.
 
 <tr>
 <td>
-
+Ok
 </td>
 <td>
 The documentation SHOULD describe the key components or modules of the codebase and their relationships, for example as a high level architectural diagram.
 </td>
 <td>
-
+<a href="https://github.com/diggsweden/open-source-project-template/tree/main#contents">Contents section</a>
 </td>
 </tr>
 
 <tr>
 <td>
-
+Ok
 </td>
 <td>
 There SHOULD be continuous integration tests for the quality of the documentation.
 </td>
 <td>
-
+<a href="https://github.com/diggsweden/open-source-project-template/tree/main/.github/workflows">Workflows</a>
 </td>
 </tr>
 
@@ -1084,13 +1084,13 @@ The codebase MUST have guidelines explaining how to structure contributions.
 
 <tr>
 <td>
-
+Ok
 </td>
 <td>
 The codebase MUST have active contributors who can review contributions.
 </td>
 <td>
-
+Not visible in the commits yet.
 </td>
 </tr>
 


### PR DESCRIPTION
## Description

This contains the assessment as performed by Jan Ainali and Eric Herman towards the Standard for Public Code version 0.7.1 as of the previous commit.

## Checklist

- [x] My contributions and commit messages follows the style guidelines of this project
- [x] I have made corresponding changes to the documentation
- [ ] New and existing unit tests pass locally with my changes
- [x] The Pull Request has an informative and human-readable title
- [x] Changes are limited to a single goal (avoid scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] I confirm that I have read any Contribution guidelines (CONTRIBUTING)
- [x] I confirm that I wrote and/or have the right to submit the contents of my PR, by agreeing to the _Developer Certificate of Origin_, by adding a 'sign-off' to my commits
