### PR TITLE
fix: correct link to CONTRIBUTING

### DIFF
--- a/CONTRIBUTING.adoc
+++ b/CONTRIBUTING.adoc
@@ -149,7 +149,7 @@ Security reports are *greatly* appreciated.
 [[development]]
 == Development Guidelines
 
-For a guide on how to get started with Development, see the link:./DEVELOPMENT.md[DEVELOPMENT Guide].
+For a guide on how to get started with Development, see the link:./DEVELOPMENT.adoc[DEVELOPMENT Guide].
 
 [[standards]]
 ## FOSS Standards


### PR DESCRIPTION
## Description

Fix link to CONTRIBUTING

## Checklist

- [x] My contributions and commit messages follows the style guidelines of this project
- [x] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
- [x] The Pull Request has an informative and human-readable title
- [x] Changes are limited to a single goal (avoid scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] I confirm that I have read any Contribution guidelines (CONTRIBUTING)
- [x] I confirm that I wrote and/or have the right to submit the contents of my PR, by agreeing to the _Developer Certificate of Origin_, by adding a 'sign-off' to my commits
