### PR TITLE
fix: remove trailing whitespace

### DIFF
--- a/CONTRIBUTING.adoc
+++ b/CONTRIBUTING.adoc
@@ -20,7 +20,7 @@ As a new contributor, you are in an excellent position to give us feedback to ou
 * Fix or report a bug.
 * Suggest enhancements to code, tests and documentation.
 * Report/fix problems found during installing or developer environments.
-* Add suggestions for something else that is missing. 
+* Add suggestions for something else that is missing.
 
 [[community-guideline]]
 == Community Guideline
@@ -50,7 +50,7 @@ Set the Issue label to "feature" or "enhancement".
 [[contribute-code]]
 == Contribute Code, Documentation and more
 
-You want to contribute code, documentation or 'your fantastic thing x'. 
+You want to contribute code, documentation or 'your fantastic thing x'.
 Great, however, there are some practical points to check to make sure that everything runs as smoothly as possible.
 
 * It is always best to discuss your plans beforehand, to ensure that your contribution is in line with the project goals.
@@ -68,20 +68,20 @@ Great, however, there are some practical points to check to make sure that every
 The listed project maintainers (see the link:README.md[README]) of the project are doing their best to review and/or respond to Issues. *If the project is not listed as archived, it is maintained.*
 You should expect feedback for an Issue or Pull Request in five business days.
 
-NOTE: Feedback might mean a lot of things depending on the scope of your Issue/Pull Request. 
-What you should expect is at least a comment on your Issue.  
+NOTE: Feedback might mean a lot of things depending on the scope of your Issue/Pull Request.
+What you should expect is at least a comment on your Issue.
 
-NOTE: For non trivial and proposed bigger contributions, please discuss the contribution with the project first. 
+NOTE: For non trivial and proposed bigger contributions, please discuss the contribution with the project first.
 There might be occasions where the cost of maintainance and review have to be agreed upon before it can be merged and reviewed.
 
-The quality of the given information in your Pull Request/Issue will affect the feedback loop. 
+The quality of the given information in your Pull Request/Issue will affect the feedback loop.
 So please keep the focus and topic, and be sure to give as much relevant information as possible.
 It is highly recommended that you fill in the requested fields when submitting a contribution.
 
 [[pull-request]]
 == Pull Request Lifecycle
 
-Generally speaking, you should fork this repository, make changes in your own fork, and then submit a pull-request. 
+Generally speaking, you should fork this repository, make changes in your own fork, and then submit a pull-request.
 This workflow is common, maybe even expected if nothing else mentioned, and is called the https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/getting-started/about-collaborative-development-models#fork-and-pull-model[Fork-and-Pull model]
 
 A practical example of such a workflow could be:
@@ -97,13 +97,13 @@ A practical example of such a workflow could be:
 
 === DCO - Signoff and Signing a Commit
 
-NOTE: Signoff and signing: Two similar terms for two different things + 
-**_A Signoff assures to the project that you have the right to contribute your content_** + 
+NOTE: Signoff and signing: Two similar terms for two different things +
+**_A Signoff assures to the project that you have the right to contribute your content_** +
 **_A Sign assures that the commit came from you_**
 
 ==== Signoff (DCO agree)
 
-A standard practice in the Open Source communities is the https://developercertificate.org/[DCO - Developer Certificate of Origin]. 
+A standard practice in the Open Source communities is the https://developercertificate.org/[DCO - Developer Certificate of Origin].
 DCO a lightweight way for a project to assure that the contributor wrote and/or have the right to submit the contribution.
 
 It is supersimple!
@@ -119,7 +119,7 @@ $ git commit --signoff -m 'fix: add fix for superbug x'
 
 ==== Sign
 
-You can also sign the commit with `-S`/`--gpg-sign`. 
+You can also sign the commit with `-S`/`--gpg-sign`.
 Besides extra trust, it also gives your commit a nice verified button in the UI on most Git platforms and further assures trust.
 
 Older versions of Git requires that you have a GPG keypair set up, see https://docs.github.com/en/github/authenticating-to-github/signing-commits[Sign commit on GitHub with GPG key].
@@ -151,7 +151,7 @@ If you discover a security issue, please bring it to our attention.
 
 If the vulnerability is a widely known issue, detected by various Vulnerability Scanning sources it might be okay to file an public Issue.
 
-However, if any uncertainty around this, please **DO NOT** file a public issue, see link:SECURITY.md[Security information] for how to handle this. 
+However, if any uncertainty around this, please **DO NOT** file a public issue, see link:SECURITY.md[Security information] for how to handle this.
 
 Security reports are *greatly* appreciated.
 

--- a/DEVELOPMENT.adoc
+++ b/DEVELOPMENT.adoc
@@ -44,7 +44,7 @@ Currently, the following checks are enabled:
 
 Tool: https://github.com/fsfe/reuse-tool[reuse] (license compliance check)
 
-A license compliance check is run and controls that every file has valid copyright (in the SPDX-standard format). 
+A license compliance check is run and controls that every file has valid copyright (in the SPDX-standard format).
 
 ==== Commit structure
 
@@ -58,12 +58,12 @@ You will get a summary report at the end of the script run, telling you if somet
 
 _If the locally run script shows failing checks:_
 
-You should be able to see the errors by scrolling through the output in your terminal. 
+You should be able to see the errors by scrolling through the output in your terminal.
 Fix the errors, git add the fixes to your pr and re-run the script. Hopefully it shows all green the next round.
 
 _If the CI Pipeline shows failing checks:_
 
-You can repeat the errors found by the CI by running the code quality-script locally. 
+You can repeat the errors found by the CI by running the code quality-script locally.
 Fix the errors locally, and update the Pull Request when the local tests have passed.
 The CI-tests should now show that you passed.
 

--- a/README.md
+++ b/README.md
@@ -51,12 +51,12 @@ These can be found in the 'templates'-directory. However, you should also consid
    - Correct any [Template Variables](#template-files-variables) in the Template files.
 5. Answer the questions on the [Open Source Checklist:](docs/Open_Source_Checklist.adoc)
 
-> Keep the README fresh! It's the first thing people see and will make the initial impression.  
-> Understand the contents of the files you use from this project. Do they fit within your project, or are you looking for something else?  
+> Keep the README fresh! It's the first thing people see and will make the initial impression.
+> Understand the contents of the files you use from this project. Do they fit within your project, or are you looking for something else?
 
 In the special case that you git cloned this project and are using it as a project base (instead of copying files from it), also make sure to:
 
-> Remove the .git-folder and create a new one with 'git init'.  
+> Remove the .git-folder and create a new one with 'git init'.
 > Remove any workflows that are not applicable for your application.(see the folder `.github/workflows`)
 > Remove any other project specifics like l10n (translations/.reuse and so on)
 
@@ -125,7 +125,7 @@ Most assets released are under Creative Commons CC0-1.0 except for
 
 CODE_OF_CONDUCT.md template:
 
-Copyright: [Contributor Covenant](https://www.contributor-covenant.org/)  
+Copyright: [Contributor Covenant](https://www.contributor-covenant.org/)
 License: [CC-BY-4.0](https://creativecommons.org/licenses/by/4.0/)
 
 ---

--- a/docs/Open_Source_Checklist.adoc
+++ b/docs/Open_Source_Checklist.adoc
@@ -63,7 +63,7 @@ TO-DO
 * Ensure that any maintaining team has a plan for handling community issues (responding to issues, reviewing and merging pull requests)
 * Is there a need for a release plan? - if so, ensure that is clear how it should be announced and promoted
 * Every project README MUST have a ``Maintainer''-header. Team, individual, role, does not matter. If there are no Maintainers to be found, the project should be Archived.
-** Additionally, the project SHOULD use a CODEOWNERS-file. 
+** Additionally, the project SHOULD use a CODEOWNERS-file.
   A CODEOWNERS-file can be more granualar in describing the project maintenance, whereas the README’s Maintainer-line might be more general.
 
 == Open Source Excellence

--- a/l10n/sv/CONTRIBUTING.sv.adoc
+++ b/l10n/sv/CONTRIBUTING.sv.adoc
@@ -3,32 +3,32 @@
 // SPDX-License-Identifier: CC0-1.0
 
 = Riktlinjer för bidrag
-:toc: 
+:toc:
 :revdate: {docdatetime}
 :revnumber: 0.0.0
 
-Välkommen! Vi är glada över att du är intresserad av att bidra till vårt projekt! 
-Det finns en del du kan behöva känna till först, så läs igenom följande: 
+Välkommen! Vi är glada över att du är intresserad av att bidra till vårt projekt!
+Det finns en del du kan behöva känna till först, så läs igenom följande:
 
-[[att-bidra]] 
-== Bidra 
+[[att-bidra]]
+== Bidra
 
 Det finns flera sätt att engagera sig:
 
-Att vara ny i ett projekt är ju också ett utmärkt tillfälle för att ge återkoppling. Till exempel genom att: 
- 
+Att vara ny i ett projekt är ju också ett utmärkt tillfälle för att ge återkoppling. Till exempel genom att:
+
 * Åtgärda eller rapportera fel.
-* Föreslå förbättringar till kod, dokumentation och tester. 
+* Föreslå förbättringar till kod, dokumentation och tester.
 * Rapportera/lösa problem under installation eller i utvecklarmiljö.
-* Bidra med något annat du tycker saknas. 
- 
-[[community-guideline]] 
+* Bidra med något annat du tycker saknas.
+
+[[community-guideline]]
 == Uppförandekoder för gemenskapen
- 
-Visa respekt för varandra. 
-  
+
+Visa respekt för varandra.
+
 Vi följer gemenskapens uppförandekod vid bidrag link:CODE_OF_CONDUCT.sv.md[Gemenskapens uppförandekod vid bidra].
-  
+
 [[file-issue]]
 == Skicka ett in ärende
 
@@ -39,13 +39,13 @@ Om så, lägg till en kommentar till det istället för att skapa ett nytt.
 
 Att rapportera fel är ett bra och enkelt sätt att bidra på.
 
-För att göra detta, öppna upp ett nytt ärende som sammanfattar felet och ställ in etiketten på "bug". 
+För att göra detta, öppna upp ett nytt ärende som sammanfattar felet och ställ in etiketten på "bug".
 
 === Föreslå en funktion
 
 För att begära en ny funktion bör du sammanfatta önskad funktionalitet och dess användningsfall.
 
-Ställ in etiketten för ärendet på "feature" eller "enhancenment". 
+Ställ in etiketten för ärendet på "feature" eller "enhancenment".
 
 [[contribute-code]]
 == Bidra med kod, dokumentation eller annat
@@ -55,40 +55,40 @@ Det uppskattar vi, men det finns några praktiska punkter för att se till att d
 
 * Det är bäst att diskutera dina planer i förväg för att försäkra dig om att ditt bidrag är i linje med projektets väg framåt.
 * Kontrollera listan över öppna ärenden. Du kan antingen tilldela dig ett befintligt ärende, eller skapa ett nytt som du skulle vilja arbeta med. Diskutera gärna dina idéer och användningsfall.
-* Följ projektets konventioner och stilar avseende test, kod, dokumentation och git-commit. 
+* Följ projektets konventioner och stilar avseende test, kod, dokumentation och git-commit.
 * Projektet kan tacka nej till ett bidrag som inte följer de allmänna projektriktlinjerna, eller som bedöms inte passa dess mål/arkitektur.
 * Se till att du har förståelse för link:#pull-request[Pull Request och dess flöden]
-* Du samtycker till att bidrag till detta projekt kommer släppas under normen **ingående=utgående**, det vill säga att bidrag du skickar in till projektet faller under samma licenser som projektet delas under. Mer formellt - "Om du inte uttryckligen anger annat, kommer bidrag som du skickat in för inkludering omfattas av villkoren för projektlicenserna." 
+* Du samtycker till att bidrag till detta projekt kommer släppas under normen **ingående=utgående**, det vill säga att bidrag du skickar in till projektet faller under samma licenser som projektet delas under. Mer formellt - "Om du inte uttryckligen anger annat, kommer bidrag som du skickat in för inkludering omfattas av villkoren för projektlicenserna."
 * link:#signoff-and-signing-a-commit[Underteckna din commit].
- 
-[[pull-request]] 
+
+[[pull-request]]
 == Pull Request och dess flöde
- 
-Generellt sett bör du göra en kopia (fork) av projektet till din egen användare, göra ändringar och sedan skicka en Pull Request. 
+
+Generellt sett bör du göra en kopia (fork) av projektet till din egen användare, göra ändringar och sedan skicka en Pull Request.
 Det är ett vanligt arbetsflöde, kanske också det förväntade, om inget annat nämns, https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/getting-started/about-collaborative-development-models#fork-and-pull-model[läs mer här].
 
-Ett praktiskt exempel på ett sådant arbetsflöde: 
-1. Gör en kopia av utvecklingskatalogen. 
-2. Skapa en jobbgren utifrån din kopias huvudgren. 
+Ett praktiskt exempel på ett sådant arbetsflöde:
+1. Gör en kopia av utvecklingskatalogen.
+2. Skapa en jobbgren utifrån din kopias huvudgren.
 3. Spara dina ändringar till ämnesgrenen (i din jobbgren).
 4. Öppna en ny Pull Request till huvudprojektet.
 5. Projektdeltagare kan kommentera och ge återkoppling på din Pull Request.
-    
-[[commit-guideline]] 
+
+[[commit-guideline]]
 == Commit-riktlinjer
 
 === DCO - underskrift och signering av en commit
 
 NOTE: Signoff och signering: Två liknande termer för två olika saker +
 **_En signoff försäkrar projektet om att du har rätt att bidra med ditt innehåll_** +
-**_En signering försäkrar projektet om att bidraget kom från din användare_** 
+**_En signering försäkrar projektet om att bidraget kom från din användare_**
 
-==== Signoff (DCO-underskrift) 
+==== Signoff (DCO-underskrift)
 
 En vanlig standard för öppen källkod-bidrag är användandet av https://developercertificate.org/[DCO - Developer Certificate Origin].
 DCO är sätt för ett projekt att försäkra sig om att bidragsgivaren har rätten att lämna in bidraget.
 
-Det är jätteenkelt i praktiken! 
+Det är jätteenkelt i praktiken!
 
 Du skriver under DCO genom att lägga till en *sign off* till din commit.
 Tekniskt sett sker detta genom att ange flaggan `-s`/`--signoff` enligt följande exempel:
@@ -100,7 +100,7 @@ Tekniskt sett sker detta genom att ange flaggan `-s`/`--signoff` enligt följand
 
 ==== Signera
 
-Du kan också valfritt signera din commit: `-S`/`--gpg-sign`. 
+Du kan också valfritt signera din commit: `-S`/`--gpg-sign`.
 Det ger en extra tillit, och visar din commit som verifierad i de flesta Git-plattformar.
 För denna funktion måste du ha angett GPG-nyckel, se https://docs.github.com/en/github/authenticating-to-github/signing-commits[Sign commit on GitHub with GPG key].
 
@@ -117,7 +117,7 @@ I nyare Git-versioner kan du använda din SSH-nyckel, https://github.blog/change
 
 Eftersträva en ren och mänskligt läsbar commit-historik.
 
-* **_Om projektet redan har en definierad standard för commit-meddelanden, följ den_**. 
+* **_Om projektet redan har en definierad standard för commit-meddelanden, följ den_**.
 * Godkänn att du har rätt att ge ditt bidrag med en DCO link:#dco-signoff-and-signing-a-commitsign-off[Sign-Off].
 * Vidare:
     ** För ett projekt som inte har någon commit-standard, se exempelvis https://www.conventionalcommits.org[Conventional Commit standard].

--- a/templates/CONTRIBUTING.template.adoc
+++ b/templates/CONTRIBUTING.template.adoc
@@ -20,7 +20,7 @@ As a new contributor, you are in an excellent position to give us feedback to ou
 * Fix or report a bug.
 * Suggest enhancements to code, tests and documentation.
 * Report/fix problems found during installing or developer environments.
-* Add suggestions for something else that is missing. 
+* Add suggestions for something else that is missing.
 
 [[community-guideline]]
 == Community Guideline
@@ -50,7 +50,7 @@ Set the Issue label to "feature" or "enhancement".
 [[contribute-code]]
 == Contribute Code, Documentation and more
 
-You want to contribute code, documentation or 'your fantastic thing x'. 
+You want to contribute code, documentation or 'your fantastic thing x'.
 Great, however, there are some practical points to check to make sure that everything runs as smoothly as possible.
 
 * It is always best to discuss your plans beforehand, to ensure that your contribution is in line with the project goals.
@@ -69,20 +69,20 @@ Great, however, there are some practical points to check to make sure that every
 The listed project maintainers (see the link:README.md[README]) of the project are doing their best to review and/or respond to Issues. *If the project is not listed as archived, it is maintained.*
 You should expect feedback for an Issue or Pull Request in [INSERT_DAYS] business days.
 
-NOTE: Feedback might mean a lot of things depending on the scope of your Issue/Pull Request. 
-What you should expect is at least a comment on your Issue. 
+NOTE: Feedback might mean a lot of things depending on the scope of your Issue/Pull Request.
+What you should expect is at least a comment on your Issue.
 
-NOTE: For non trivial and proposed bigger contributions, please discuss the contribution with the project first. 
+NOTE: For non trivial and proposed bigger contributions, please discuss the contribution with the project first.
 There might be occasions where the cost of maintainance and review have to be agreed upon before it can be merged and reviewed.
 
-The quality of the given information in your Pull Request/Issue will affect the feedback loop. 
+The quality of the given information in your Pull Request/Issue will affect the feedback loop.
 So please keep the focus and topic, and be sure to give as much relevant information as possible.
 It is highly recommended that you fill in the requested fields when submitting a contribution.
 
 [[pull-request]]
 == Pull Request Lifecycle
 
-Generally speaking, you should fork this repository, make changes in your own fork, and then submit a pull-request. 
+Generally speaking, you should fork this repository, make changes in your own fork, and then submit a pull-request.
 This workflow is common, maybe even expected if nothing else mentioned, and is called the https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/getting-started/about-collaborative-development-models#fork-and-pull-model[Fork-and-Pull model]
 
 A practical example of such a workflow could be:
@@ -98,13 +98,13 @@ A practical example of such a workflow could be:
 
 === DCO - Signoff and Signing a Commit
 
-NOTE: Signoff and signing: Two similar terms for two different things + 
-**_A Signoff assures to the project that you have the right to contribute your content_** + 
+NOTE: Signoff and signing: Two similar terms for two different things +
+**_A Signoff assures to the project that you have the right to contribute your content_** +
 **_A Sign assures that the commit came from you_**
 
 ==== Signoff (DCO agree)
 
-A standard practice in the Open Source communities is the https://developercertificate.org/[DCO - Developer Certificate of Origin]. 
+A standard practice in the Open Source communities is the https://developercertificate.org/[DCO - Developer Certificate of Origin].
 DCO a lightweight way for a project to assure that the contributor wrote and/or have the right to submit the contribution.
 
 It is supersimple!
@@ -120,7 +120,7 @@ $ git commit --signoff -m 'fix: add fix for superbug x'
 
 ==== Sign
 
-You can also sign the commit with `-S`/`--gpg-sign`. 
+You can also sign the commit with `-S`/`--gpg-sign`.
 Besides extra trust, it also gives your commit a nice verified button in the UI on most Git platforms and further assures trust.
 
 Older versions of Git requires that you have a GPG keypair set up, see https://docs.github.com/en/github/authenticating-to-github/signing-commits[Sign commit on GitHub with GPG key].
@@ -135,7 +135,7 @@ For newer versions you can use SSH for signing https://github.blog/changelog/202
 
 Aim for a clear human readable commit history:
 
-* **_First - does the project have a defined commit message practice, please follow that_**. 
+* **_First - does the project have a defined commit message practice, please follow that_**.
 * Make sure you link:#dco-signoff-and-signing-a-commitsign-off[Sign-Off] your commits.
 * In general
     ** If the project does not have standard for commits, you might want to consider https://www.conventionalcommits.org[Conventional Commit standard].
@@ -153,7 +153,7 @@ If you discover a security issue, please bring it to our attention.
 
 If the vulnerability is a widely known issuee, detected by various Vulnerability Scanning sources it might be okay to file an public Issue.
 
-However, if any uncertainty around this, please **DO NOT** file a public issue, see link:SECURITY.md[Security information] for how to handle this. 
+However, if any uncertainty around this, please **DO NOT** file a public issue, see link:SECURITY.md[Security information] for how to handle this.
 
 Security reports are *greatly* appreciated.
 


### PR DESCRIPTION
## Description

Many files had lines with trailing whitespace, which can cause issues during merges.

Fixes #14

## Checklist

- [x] My contributions and commit messages follows the style guidelines of this project
- [x] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
- [x] The Pull Request has an informative and human-readable title
- [x] Changes are limited to a single goal (avoid scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] I confirm that I have read any Contribution guidelines (CONTRIBUTING)
- [x] I confirm that I wrote and/or have the right to submit the contents of my PR, by agreeing to the _Developer Certificate of Origin_, by adding a 'sign-off' to my commits
