### PR TITLE
docs: update standard for public code assessment

### DIFF
--- a/docs/public_code/standard-for-public-code-assessment.html
+++ b/docs/public_code/standard-for-public-code-assessment.html
@@ -306,7 +306,7 @@ The software SHOULD NOT require services or platforms available from only a sing
 
 <h2><a href="https://standard.publiccode.net/criteria/welcome-contributors.html">Welcome contributors</a></h2>
 
-&#9744;<!-- &#9745; --> criterion met.
+&#9745;<!-- &#9745; --> criterion met.
 
 <table id="welcome-contributors" style="width:100%">
 <tr><th>Meets</th><th>Requirement</th><th style="width:25%">Notes and links</th></tr>
@@ -336,13 +336,13 @@ The codebase MUST include contribution guidelines explaining what kinds of contr
 
 <tr>
 <td>
-
+Ok
 </td>
 <td>
 The codebase MUST document the governance of the codebase, contributions and its community, for example in a `GOVERNANCE` file.
 </td>
 <td>
-
+<a href="https://github.com/diggsweden/open-source-project-template#maintainers">Maintainers</a> and <a href="https://github.com/diggsweden/open-source-project-template/blob/main/CODEOWNERS">CODEOWNERS</a>
 </td>
 </tr>
 
@@ -618,7 +618,7 @@ Reviews MUST include source, policy, tests and documentation.
 Reviewers MUST provide feedback on all decisions to not accept a contribution.
 </td>
 <td>
-
+There is a an expectation given to the contributor in <a href="https://github.com/diggsweden/open-source-project-template/blob/main/CONTRIBUTING.adoc#issues-and-pull-request-feedback>CONTRIBUTING.adoc</a> but no explicit guidelines or policy for the reviewer.
 </td>
 </tr>
 
@@ -678,7 +678,7 @@ Version control systems SHOULD NOT accept non-reviewed contributions in release 
 Reviews SHOULD happen within two business days.
 </td>
 <td>
-"A few days" is mentioned in <a href="https://github.com/diggsweden/open-source-project-template/blob/main/CONTRIBUTING.adoc#issues-and-pull-request-feedback">Issues and Pull Request Feedback</a>, but it is not specific enough.
+The expectation for "five business days" is set in <a href="https://github.com/diggsweden/open-source-project-template/blob/main/CONTRIBUTING.adoc#issues-and-pull-request-feedback">Issues and Pull Request Feedback</a>. However, what we are seeing is that feedback is usually faster.
 </td>
 </tr>
 
@@ -888,13 +888,13 @@ All source code MUST be in English, except where policy is machine interpreted a
 
 <tr>
 <td>
-
+Ok
 </td>
 <td>
 All bundled policy not available in English MUST have an accompanying summary in English.
 </td>
 <td>
-A summary of the policy in English would be good.
+<a href="https://github.com/diggsweden/open-source-project-template#diggs-open-source-policy-summary"> A summary of the policy in English</a>.
 </td>
 </tr>
 
@@ -930,7 +930,7 @@ There SHOULD be no acronyms, abbreviations, puns or legal/non-English/domain spe
 Documentation SHOULD aim for a lower secondary education reading level, as recommended by the <a href="https://www.w3.org/WAI/WCAG21/quickref/?showtechniques=315#readable">Web Content Accessibility Guidelines 2</a>.
 </td>
 <td>
-
+Could add a note to the CONTRIBUTING that this should be aimed for.
 </td>
 </tr>
 
@@ -1066,7 +1066,7 @@ All functionality in the source code MUST have automated tests.
 Contributions MUST pass all automated tests before they are admitted into the codebase.
 </td>
 <td>
-
+True by practice but not explicitely documented.
 </td>
 </tr>
 
@@ -1096,13 +1096,13 @@ Not visible in the commits yet.
 
 <tr>
 <td>
-
+Ok
 </td>
 <td>
 Automated test results for contributions SHOULD be public.
 </td>
 <td>
-
+<a href="https://github.com/diggsweden/open-source-project-template/actions">Github Actions</a>
 </td>
 </tr>
 
@@ -1126,7 +1126,7 @@ The codebase guidelines SHOULD state that each contribution should focus on a si
 Source code test and documentation coverage SHOULD be monitored.
 </td>
 <td>
-
+Not all files are linted and this isn't reported. See also <a href="https://github.com/diggsweden/open-source-project-template/issues/13">issue #13</a>
 </td>
 </tr>
 


### PR DESCRIPTION
## Description

This contains the assessment as performed by Jan Ainali and Eric Herman towards the Standard for Public Code version 0.7.1 as of the previous commit.

## Checklist

- [x] My contributions and commit messages follows the style guidelines of this project
- [x] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
- [x] The Pull Request has an informative and human-readable title
- [x] Changes are limited to a single goal (avoid scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] I confirm that I have read any Contribution guidelines (CONTRIBUTING)
- [x] I confirm that I wrote and/or have the right to submit the contents of my PR, by agreeing to the _Developer Certificate of Origin_, by adding a 'sign-off' to my commits
