### PR TITLE
Spelling fixes

### DIFF
--- a/CONTRIBUTING.adoc
+++ b/CONTRIBUTING.adoc
@@ -72,7 +72,7 @@ NOTE: Feedback might mean a lot of things depending on the scope of your Issue/P
 What you should expect is at least a comment on your Issue.  
 
 NOTE: For non trivial and proposed bigger contributions, please discuss the contribution with the project first. 
-There might be occasions where the cost of maintainance and review have to be agreed upon before it can be merged and reviewed.
+There might be occasions where the cost of maintenance and review have to be agreed upon before it can be merged and reviewed.
 
 The quality of the given information in your Pull Request/Issue will affect the feedback loop. 
 So please keep the focus and topic, and be sure to give as much relevant information as possible.
@@ -106,7 +106,7 @@ NOTE: Signoff and signing: Two similar terms for two different things +
 A standard practice in the Open Source communities is the https://developercertificate.org/[DCO - Developer Certificate of Origin]. 
 DCO a lightweight way for a project to assure that the contributor wrote and/or have the right to submit the contribution.
 
-It is supersimple!
+It is super simple!
 
 As part of filing a pull request you agree to the DCO - by just adding a *sign off*  to your commit.
 Technically, this is done by supplying the `-s`/`--signoff` flag to your Git commits:

--- a/DEVELOPMENT.adoc
+++ b/DEVELOPMENT.adoc
@@ -7,7 +7,7 @@
 :revnumber: 0.0.0
 :imagesdir: assets
 
-If you submit a Pull Request to this project, a few checks will be run on it with Continous Integration.
+If you submit a Pull Request to this project, a few checks will be run on it with Continuous Integration.
 Luckily, you can (as in, really should) run the checks locally to avoid surprises.
 
 [[code-quality]]
@@ -24,7 +24,7 @@ $ ./development/code_quality.sh
 
 The script is dependent on https://podman.io/[podman].
 
-The resulting out put should be pretty self explantory.
+The resulting output should be pretty self explanatory.
 
 ===  What quality checks are done?
 

--- a/development/mega-linter.yml
+++ b/development/mega-linter.yml
@@ -24,7 +24,7 @@ GITHUB_STATUS_REPORTER: true
 GITLAB_COMMENT_REPORTER: false
 UPDATED_SOURCES_REPORTER: true
 
-# Lint specifig settings
+# Lint specific settings
 ENABLE_LINTERS:
   [
     BASH_SHELLCHECK,

--- a/l10n/sv/CONTRIBUTING.sv.adoc
+++ b/l10n/sv/CONTRIBUTING.sv.adoc
@@ -45,7 +45,7 @@ För att göra detta, öppna upp ett nytt ärende som sammanfattar felet och st�
 
 För att begära en ny funktion bör du sammanfatta önskad funktionalitet och dess användningsfall.
 
-Ställ in etiketten för ärendet på "feature" eller "enhancenment". 
+Ställ in etiketten för ärendet på "feature" eller "enhancement".
 
 [[contribute-code]]
 == Bidra med kod, dokumentation eller annat

--- a/templates/CONTRIBUTING.template.adoc
+++ b/templates/CONTRIBUTING.template.adoc
@@ -73,7 +73,7 @@ NOTE: Feedback might mean a lot of things depending on the scope of your Issue/P
 What you should expect is at least a comment on your Issue. 
 
 NOTE: For non trivial and proposed bigger contributions, please discuss the contribution with the project first. 
-There might be occasions where the cost of maintainance and review have to be agreed upon before it can be merged and reviewed.
+There might be occasions where the cost of maintenance and review have to be agreed upon before it can be merged and reviewed.
 
 The quality of the given information in your Pull Request/Issue will affect the feedback loop. 
 So please keep the focus and topic, and be sure to give as much relevant information as possible.
@@ -107,7 +107,7 @@ NOTE: Signoff and signing: Two similar terms for two different things +
 A standard practice in the Open Source communities is the https://developercertificate.org/[DCO - Developer Certificate of Origin]. 
 DCO a lightweight way for a project to assure that the contributor wrote and/or have the right to submit the contribution.
 
-It is supersimple!
+It is super simple!
 
 As part of filing a pull request you agree to the DCO - by just adding a *sign off*  to your commit.
 Technically, this is done by supplying the `-s`/`--signoff` flag to your Git commits:
@@ -151,7 +151,7 @@ Aim for a clear human readable commit history:
 
 If you discover a security issue, please bring it to our attention.
 
-If the vulnerability is a widely known issuee, detected by various Vulnerability Scanning sources it might be okay to file an public Issue.
+If the vulnerability is a widely known issue, detected by various Vulnerability Scanning sources it might be okay to file an public Issue.
 
 However, if any uncertainty around this, please **DO NOT** file a public issue, see link:SECURITY.md[Security information] for how to handle this. 
 


### PR DESCRIPTION
Found and fixed a number of minor spelling typos and errors.

## Checklist

- [x] My contributions and commit messages follows the style guidelines of this project
- [x] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
- [x] The Pull Request has an informative and human-readable title
- [x] Changes are limited to a single goal (avoid scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] I confirm that I have read any Contribution guidelines (CONTRIBUTING)
- [x] I confirm that I wrote and/or have the right to submit the contents of my PR, by agreeing to the _Developer Certificate of Origin_, by adding a 'sign-off' to my commits
