### PR TITLE
Update Standard for public code assessment

### DIFF
--- a/docs/public_code/standard-for-public-code-assessment.html
+++ b/docs/public_code/standard-for-public-code-assessment.html
@@ -618,7 +618,7 @@ Reviews MUST include source, policy, tests and documentation.
 Reviewers MUST provide feedback on all decisions to not accept a contribution.
 </td>
 <td>
-There is a an expectation given to the contributor in <a href="https://github.com/diggsweden/open-source-project-template/blob/main/CONTRIBUTING.adoc#issues-and-pull-request-feedback>CONTRIBUTING.adoc</a> but no explicit guidelines or policy for the reviewer.
+There is a an expectation given to the contributor in <a href="https://github.com/diggsweden/open-source-project-template/blob/main/CONTRIBUTING.adoc#issues-and-pull-request-feedback>CONTRIBUTING.adoc">CONTRIBUTING</a> but no explicit guidelines or policy for the reviewer.
 </td>
 </tr>
 
@@ -742,7 +742,7 @@ Documenting the objectives of the codebase for the general public is OPTIONAL.
 
 <h2><a href="https://standard.publiccode.net/criteria/document-the-code.html">Document the code</a></h2>
 
-&#9744;<!-- &#9745; --> criterion met.
+&#9745;<!-- &#9745; --> criterion met.
 
 <table id="document-the-code" style="width:100%">
 <tr><th>Meets</th><th>Requirement</th><th style="width:25%">Notes and links</th></tr>
@@ -1256,7 +1256,7 @@ Having multiple licenses for different types of source code and documentation is
 <tr><th>Meets</th><th>Requirement</th><th style="width:25%">Notes and links</th></tr>
 <tr>
 <td>
-
+Ok
 </td>
 <td>
 The name of the codebase SHOULD be descriptive and free from acronyms, abbreviations, puns or organizational branding.
@@ -1268,7 +1268,7 @@ The name of the codebase SHOULD be descriptive and free from acronyms, abbreviat
 
 <tr>
 <td>
-
+Ok
 </td>
 <td>
 The codebase SHOULD have a short description that helps someone understand what the codebase is for or what it does.
@@ -1286,7 +1286,7 @@ The codebase SHOULD have a short description that helps someone understand what 
 Maintainers SHOULD submit the codebase to relevant software catalogs.
 </td>
 <td>
-
+Shows up in <a href="https://api.reuse.software/info/github.com/diggsweden/open-source-project-template">the REUSE API</a> but not in any searchable catalog. 
 </td>
 </tr>
 
@@ -1316,13 +1316,13 @@ It is SHOULD for the codebase to be findable using a search engine by codebase n
 
 <tr>
 <td>
-
+Ok
 </td>
 <td>
 The codebase SHOULD be findable using a search engine by describing the problem it solves in natural language.
 </td>
 <td>
-
+Shows up in Google and Yahoo, Duckduckgo and Bing found forks of it.
 </td>
 </tr>
 
@@ -1384,13 +1384,13 @@ Regular presentations at conferences by the community are OPTIONAL.
 <tr><th>Meets</th><th>Requirement</th><th style="width:25%">Notes and links</th></tr>
 <tr>
 <td>
-
+Ok
 </td>
 <td>
 The codebase MUST use a coding or writing style guide, either the codebase community's own or an existing one referred to in the codebase.
 </td>
 <td>
-
+In <a href="https://github.com/diggsweden/open-source-project-template/blob/main/CONTRIBUTING.adoc#writing_style">CONTRIBUTING</a>
 </td>
 </tr>
 
@@ -1408,7 +1408,7 @@ Contributions SHOULD pass automated tests on style.
 
 <tr>
 <td>
-
+N/A
 </td>
 <td>
 The style guide SHOULD include expectations for inline comments and documentation for non-trivial sections.
@@ -1464,13 +1464,13 @@ The codebase MUST prominently document whether or not there are versions of the 
 
 <tr>
 <td>
-
+N/A
 </td>
 <td>
 Codebase versions that are ready to use MUST only depend on versions of other codebases that are also ready to use.
 </td>
 <td>
-
+No dependencies except for testing which is not required for the templates themself.
 </td>
 </tr>
 


### PR DESCRIPTION
## Description

This contains the assessment as performed by Jan Ainali and Eric Herman towards the Standard for Public Code version 0.7.1 as of the previous commit.
Fixes #(issue)

## Checklist

- [x] My contributions and commit messages follows the style guidelines of this project
- [x] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
- [x] The Pull Request has an informative and human-readable title
- [x] Changes are limited to a single goal (avoid scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] I confirm that I have read any Contribution guidelines (CONTRIBUTING)
- [x] I confirm that I wrote and/or have the right to submit the contents of my PR, by agreeing to the _Developer Certificate of Origin_, by adding a 'sign-off' to my commits
