### PR TITLE
docs: add basic governance files

### DIFF
--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -1,0 +1,30 @@
+<!--
+SPDX-FileCopyrightText: 2023 Digg - Agency for Digital Government
+
+SPDX-License-Identifier: CC0-1.0
+-->
+
+# Governance
+
+Decisions related to the project's direction, new features, and significant changes are made through a consensus-based process involving the maintainers and contributors.
+We value open and transparent decision-making and strive to involve the community in shaping the project's future.  
+
+## Roles
+
+This section describes the different roles, their responsibilities, and how they are selected.
+
+### Maintainers
+
+The project is maintained by a group of individuals who are responsible for overseeing the project's development, ensuring the adherence to the project's values, and making important decisions.
+
+The maintainers are responsible for:  
+    - Reviewing contributions
+    - Setting project goals and priorities
+    - Resolving conflicts and disputes within the community
+    - Adhering to the code of conduct
+
+The maintainers are selected based on their contributions, expertise, and dedication to the project's mission.  
+
+### Contributors
+
+We welcome contributions, whether they are code contributions, bug reports, feature requests, documentation improvements, or discussions.

--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ These can be found in the 'templates'-directory. However, you should also consid
   - `.github/` - contains GitHub specific versions of bug-, pr, feature-templates.
   - `.github/workflows` - contains GitHub workflows for this project. You will most likely write your own workflows for your project.
 - CHANGELOG - Describes the project updates in a standard human readable way. Version: [Keep-a-changelog 1.1.0](https://keepachangelog.com/en/1.1.0/).
+- GOVERNANCE - Describes decision making and roles in the project.
 - CODEOWNERS - Describes the maintainers in a de-facto standard way: [GitHub link about CODEOWNERS](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners)
 
 ### Docs
@@ -82,12 +83,12 @@ There are future plans for this template project.
 ### Before version 0.1.0 is released
 
 Currently, the project is undergoing a feedback revision from Foundation for Public Code, and other initial improvements.
-After that, 0.1.0 will be tagged.
+After that, a 0.1.0 will be tagged.
 
 ### Future
 
 - Mention project excellence additions (extras in the checklist?) - OpenSSF scorecard, Foundation for Public Codes metadata standard and so on.
-- Handling GOVERNANCE.md recomendations? Clearify briefly what asom digg is and how decisions are taken etc.
+- Be somewhat formal in the Open Source Checklist recommendations.
 - Handling DEVELOPMENT.md recommendations?
 - Keep the Swedish translations up-to-date
 - Handling where to recommend communication channels for users and developers

--- a/l10n/sv/GOVERNANCE.sv.template.md
+++ b/l10n/sv/GOVERNANCE.sv.template.md
@@ -1,0 +1,29 @@
+<!--
+SPDX-FileCopyrightText: 2023 Digg - Agency for Digital Government
+
+SPDX-License-Identifier: CC0-1.0
+-->
+
+# Projektstyrning
+
+Beslut som rör projektets inriktning, nya funktioner och betydande förändringar fattas genom konsensus mellan projektansvariga och bidragsgivarna.
+Vi värdesätter öppet och transparent beslutsfattande och strävar efter att involvera gemenskapen("communityn").
+
+## Roller
+
+I det här avsnittet beskrivs de olika rollerna, deras ansvarsområden och hur de väljs ut.
+
+### Projektansvariga ("Maintainer")
+
+Projektet underhålls av en grupp personer som ansvarar för att övervaka projektets utveckling, se till att projektets värderingar efterlevs och fatta viktiga beslut.
+Upprätthållarna är ansvariga för:  
+    - Granskning av bidrag
+    - Fastställa projektets mål och prioriteringar
+    - Lösa konflikter och tvister inom communityn
+    - Följa uppförandekoden
+
+Projektansvariga väljs ut baserat på deras bidrag, expertis och engagemang för projektets uppdrag.  
+
+### Bidragsgivare ("Contributor")
+
+vi välkomnar bidrag, oavsett om det gäller kod, felrapporter, förbättringar, dokumentation eller diskussioner.

--- a/templates/GOVERNANCE.template.md
+++ b/templates/GOVERNANCE.template.md
@@ -1,0 +1,30 @@
+<!--
+SPDX-FileCopyrightText: 2023 Digg - Agency for Digital Government
+
+SPDX-License-Identifier: CC0-1.0
+-->
+
+# Governance
+
+Decisions related to the project's direction, new features, and significant changes are made through a consensus-based process involving the maintainers and contributors.
+We value open and transparent decision-making and strive to involve the community in shaping the project's future.  
+
+## Roles
+
+This section describes the different roles, their responsibilities, and how they are selected.
+
+### Maintainers
+
+The project is maintained by a group of individuals who are responsible for overseeing the project's development, ensuring the adherence to the project's values, and making important decisions.
+
+The maintainers are responsible for:  
+    - Reviewing contributions
+    - Setting project goals and priorities
+    - Resolving conflicts and disputes within the community
+    - Adhering to the code of conduct
+
+The maintainers are selected based on their contributions, expertise, and dedication to the project's mission.  
+
+### Contributors
+
+We welcome contributions, whether they are code contributions, bug reports, feature requests, documentation improvements, or discussions.


### PR DESCRIPTION
Adds a GOVERNANCE-template, a Swedish version of the template and a project.
It is really a low key GOVERNANCE-file, as a general reminder that governance is considered rather than a full blown example for a major project.

## Checklist

- [x] My contributions and commit messages follows the style guidelines of this project
- [x] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
- [x] The Pull Request has an informative and human-readable title
- [x] Changes are limited to a single goal (avoid scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] I confirm that I have read any Contribution guidelines (CONTRIBUTING)
- [x] I confirm that I wrote and/or have the right to submit the contents of my PR, by agreeing to the _Developer Certificate of Origin_, by adding a 'sign-off' to my commits
