### PR TITLE
feat: add basic publiccode.yml

### DIFF
--- a/.github/workflows/lintpubliccode.yml
+++ b/.github/workflows/lintpubliccode.yml
@@ -1,0 +1,17 @@
+# SPDX-FileCopyrightText: 2023 Digg - Agency for Digital Government
+#
+# SPDX-License-Identifier: CC0-1.0
+
+---
+name: LintPublicCodeMeta
+on: [workflow_call] # yamllint disable-line rule:truthy
+
+jobs:
+  publiccode_validation:
+    runs-on: ubuntu-latest
+    name: publiccode validation
+    steps:
+      - uses: actions/checkout@v3
+      - uses: italia/publiccode-parser-action@v1
+        with:
+          publiccode: "publiccode.yml"

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -22,3 +22,5 @@ jobs:
     uses: ./.github/workflows/license.yml
   lint:
     uses: ./.github/workflows/lint.yml
+  lintpubliccode:
+    uses: ./.github/workflows/lintpubliccode.yml

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ SPDX-License-Identifier: CC0-1.0
 [![Standard commitment](https://github.com/publiccodenet/standard/blob/develop/assets/standard-for-public-code-commitment.svg)](https://github.com/diggsweden/open-source-project-template/blob/main/CONTRIBUTING.adoc#standard-for-public-code)
 [![REUSE status](https://api.reuse.software/badge/github.com/diggsweden/open-source-project-template)](https://api.reuse.software/info/github.com/diggsweden/open-source-project-template)
 
-This a template project containing 'Community Health Files' and relevant checklists.
+This is a template project containing 'Community Health Files' and relevant checklists.
 Its intention is to be a practical starter when releasing a project as Open Source.
 It was created in a general way to be usable for anyone, and proposes well known conventions and de-facto standards when possible.
 However, It is slightly opinionated, so adjust it to suit your specific needs. Or even:

--- a/development/code_quality.sh
+++ b/development/code_quality.sh
@@ -57,6 +57,13 @@ lint() {
   printf '\n\n'
 }
 
+publiccodelint() {
+  print_header 'LINTER publiccode.yml (publiccode.yml)'
+  podman run --rm -i italia/publiccode-parser-go -no-network /dev/stdin <publiccode.yml
+  store_exit_code "$?" "publiccode" "${MISSING} ${RED}Lint of publiccode check failed, see logs and fix problems.${NC}\n" "${GREEN}${CHECKMARK}${CHECKMARK} Lint check for publiccode.yml passed${NC}\n"
+  printf '\n\n'
+}
+
 license() {
   print_header 'LICENSE HEALTH (REUSE)'
   podman run --rm --volume "$(pwd)":/data docker.io/fsfe/reuse:2-debian lint
@@ -99,6 +106,7 @@ check_exit_codes() {
 is_command_available 'podman' 'https://podman.io/'
 
 lint
+publiccodelint
 license
 commit
 

--- a/docs/Open_Source_Checklist.adoc
+++ b/docs/Open_Source_Checklist.adoc
@@ -4,22 +4,20 @@
 = The Open Source Release Checklist
 :toc:
 :revdate: {docdatetime}
-:revnumber: 0.0.0
+:revnumber: 0.0.1
 
 == About
+It is easy to overlook a few important tasks when releasing and enhancing an Open Source Project.
+This checklist is here to assist your project with suggestions.
 
-It is easy to forget a few important tasks when releasing and improving an Open Source Project.
-This checklist is here to help your project with suggestions.
-
-Use this checklist in a practical way - as a discussion starter for the project, as a base for future improvements.
+Use this checklist practically - as a discussion starter for the project and as a foundation for future improvements.
 
 == Documentation
 
-* Verify that the project fulfills the basic standard of Community
-Health Files (CHANGELOG, CONTRIBUTING etc). +
-  See link:.././README.md[README.md - Template Files Explanation Section] for
-a basic list and further information
-* Add any relevant, usage documentation, Software Architecture Descriptions regarding the project
+* Ensure that the project complies with the basic conventions of Community Health Files (CHANGELOG, CONTRIBUTING, etc.). +
+Please refer to the link:.././README.md[README.md - Template Files Explanation Section] for a basic list and further information.
+
+* Include any relevant usage documentation and software architecture descriptions concerning the project.
 
 == Workflows
 
@@ -27,49 +25,56 @@ a basic list and further information
 
 == Project Quality
 
-* Verify there has been a code review of the project
-* Discuss and implement the projects testing goals and ambitions
+* Verify that the project has undergone a code review.
+* Discuss and establish the project's testing goals and ambitions.
 
-== Release and versioning
+== Release and Versioning
 
 * Use semantic versioning and release tags
 
-== Naming and trademarks check
+== Naming and Trademarks Check
 
-* Ensure that the project name does not conflict with an existing
-project or infringe on trademarks
-** Do a general sanity search engine check of the proposed project name.
-** Do a trademark search at
-https://www.prv.se/sv/immaterialrattsexpert/varumarke/databaser/[PRV]
+* Ensure that the project name does not conflict with an existing project or infringe on trademarks
+** Conduct a general search engine check for the proposed project name.
+** Perform a https://www.prv.se/en/ip-professional/trademarks/trademark-databases/[Trademark Search]
 +
-____
-It might be ok to use a name that is reminiscent of an existing trademark, if the existing trademark is used for other services/areas and is not recognized as a known trademark.
-____
+NOTE: It might be perfectly acceptable to use a name reminiscent of an existing trademark if the existing trademark is used for other services/areas and is not recognized as a well-known trademark.
 
 == Legal and Licensing
 
-* Ensure that the license of the project is not in conflict with third party licenses
-* Declare the licenses for _other resources than code_ (images, text etc). https://reuse.software[REUSE] will help you describe these.
+* Ensure that the project's license does not conflict with third-party licenses.
+* Declare the licenses for resources other than code (images, text, etc.).
 
 == Security
 
-TO-DO
 * For Security details regarding GitHub-usage or Contributor-specific security, see (Under-Construction: How we work on GitHub and link:../CONTRIBUTING.adoc[CONTRIBUTING]
 
-== People & maintenance
-
-* Ensure there is a maintenance and archival (if non maintained) plan
+== People & Maintenance
+* Ensure there is a maintenance and archival plan (if the project becomes non-maintained).
 * Ensure that any maintaining team has gotten some education or experience regarding working Open Source
 * Ensure that any maintaining team has a plan for handling community issues (responding to issues, reviewing and merging pull requests)
-* Is there a need for a release plan? - if so, ensure that is clear how it should be announced and promoted
-* Every project README MUST have a ``Maintainer''-header. Team, individual, role, does not matter. If there are no Maintainers to be found, the project should be Archived.
+* Is there a need for a release plan? If so, ensure that is clear how it should be announced and promoted
+* Every project README MUST have a ``Maintainer'' header. Wheter it's a team, an individual, or a role, does not matter.
+* If no Maintainers are found, the project SHOULD be archived.
 ** Additionally, the project SHOULD use a CODEOWNERS-file.
-  A CODEOWNERS-file can be more granualar in describing the project maintenance, whereas the README’s Maintainer-line might be more general.
-
+  A CODEOWNERS-file can provide more granualarity in describing project maintenance, whereas the README’s Maintainer heading might be more general.
 == Open Source Excellence
 
-There a quite a few extra steps you might want to consider for keeping your Open Source Projects clean, clear, re-usable, accessible and up-to-date.
+There are a few additional actions you might want to consider.
+These will help your Open Source Project to be collaborative, reusable, accessible, and up-to-date.
 
-* Consider https://reuse.software/[following the REUSE licensing standard]
-* Prefer declaring licenses with the https://spdx.github.io/spdx-spec/v2.3/using-SPDX-short-identifiers-in-source-files/[SPDX-standard]
-* Consider following the https://standard.publiccode.net/[criterias from Foundation for Public Code]
+.Open Source Excellence
+[cols="1,1"]
+|===
+| What | Why
+
+| https://reuse.software/[The REUSE licensing specification]
+| To simplify licensing compliance and declarations.
+
+| https://standard.publiccode.net/[The Foundation for Public Code Criteria]
+| To ensure collaboration and project openness follow best practices.
+
+| https://yml.publiccode.tools/index.html[The publiccode.yml file].
+| To facilitate project metadata indexing.
+
+|===

--- a/publiccode.yml
+++ b/publiccode.yml
@@ -1,0 +1,48 @@
+# SPDX-FileCopyrightText: 2023 Digg - Agency for Digital Government
+#
+# SPDX-License-Identifier: CC0-1.0
+
+# This repository adheres to the publiccode.yml standard by including this
+# metadata file that makes public software easily discoverable.
+# More info at https://github.com/italia/publiccode.yml
+
+publiccodeYmlVersion: "0.3"
+categories:
+  - collaboration
+description:
+  en:
+    features:
+      - Template
+    genericName: Template
+    longDescription: |
+      This is a template project containing 'Community Health  Files' and relevant
+      checklists. Its intention is to be a practical starter when releasing a
+      project as  Open Source. It was created in a general way to be usable for
+      anyone, and proposes  well known conventions and de-facto standards when
+      possible. However, It is slightly opinionated, so adjust it to suit your
+      specific  needs. Or even:
+
+
+      **You **_**are supposed**_** to adjust the contents and suggestions to
+      suit your project needs.          **
+    shortDescription: "https://github.com/diggsweden/open-source-project-template"
+developmentStatus: development
+legal:
+  license: CC0-1.0
+localisation:
+  availableLanguages:
+    - en
+    - sv
+  localisationReady: true
+maintenance:
+  contacts:
+    - name: ospo@digg.se
+  type: internal
+name: open source project template
+platforms:
+  - web
+releaseDate: "2023-10-16"
+softwareType: standalone/other
+softwareVersion: dev
+url: "https://github.com/diggsweden/open-source-project-template.git"
+roadmap: "https://github.com/diggsweden/open-source-project-template#roadmap"


### PR DESCRIPTION
This PR adds a basic publiccode.yml file. 

It also add a linter check to the codequality script, and a corresponding ci-check.

In a seperate commit it adds a note about about the file, and also improves (I hope) a bit of the language in the same file.

The publiccode.yml added here is to be seen as basic, not final, and will change in the future, when having discussed a few topics.

(For project externals browsing this pr, publiccode.yml is a metadata specification, read more about it here https://yml.publiccode.tools)


## Checklist

- [x] My contributions and commit messages follows the style guidelines of this project
- [x] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
- [x] The Pull Request has an informative and human-readable title
- [x] Changes are limited to a single goal (avoid scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] I confirm that I have read any Contribution guidelines (CONTRIBUTING)
- [x] I confirm that I wrote and/or have the right to submit the contents of my PR, by agreeing to the _Developer Certificate of Origin_, by adding a 'sign-off' to my commits
