### PR TITLE
docs: clean up pull request template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,12 +1,4 @@
-<!--
-SPDX-FileCopyrightText: 2023 Digg - Agency for Digital Government
-
-SPDX-License-Identifier: CC0-1.0
--->
-
-# Pull Request Template
-
-## Description
+# Description
 
 Please include a summary of the change and which issue is fixed or added.
 Please also include relevant motivation and context.
@@ -16,11 +8,6 @@ Fixes #(issue)
 
 ## Checklist
 
-- [ ] My contributions and commit messages follows the style guidelines of this project
-- [ ] I have made corresponding changes to the documentation
-- [ ] New and existing unit tests pass locally with my changes
-- [ ] The Pull Request has an informative and human-readable title
-- [ ] Changes are limited to a single goal (avoid scope creep)
-- [ ] Code can be automatically merged (no conflicts)
-- [ ] I confirm that I have read any Contribution guidelines (CONTRIBUTING)
-- [ ] I confirm that I wrote and/or have the right to submit the contents of my PR, by agreeing to the _Developer Certificate of Origin_, by adding a 'sign-off' to my commits
+- [x] Changes are limited to a single goal (avoid scope creep)
+- [x] I confirm that I have read any Contribution and Development guidelines (CONTRIBUTING and DEVELOPMENT) and are following their suggestions.
+- [ ] I confirm that I wrote and/or have the right to submit the contents of my Pull Request, by agreeing to the _Developer Certificate of Origin_, (adding a 'sign-off' to my commits).

--- a/.reuse/dep5
+++ b/.reuse/dep5
@@ -3,3 +3,7 @@ Format: https://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
 Files: assets/*.png
 Copyright: Digg - Agency for Digital Government
 License: CC0-1.0
+
+Files: .github/pull_request_template.md
+Copyright: Digg - Agency for Digital Government
+License: CC0-1.0


### PR DESCRIPTION
The current general pr template had some problems.
- The spdx info would be shown -> confusing for new user
- The checklist was quite long and tedious.
- There was an extra markdown header

Fix:
- spdx declarations is now in .reuse/dep5
- Checklist points to user having read CONTRIBUTING , DEVELOPMENT (where everything listed before is said.
- Checklist saves a few "clicks" by having the expected items preclicked. The only active click is DCO.

## Checklist

- [x] My contributions and commit messages follows the style guidelines of this project
- [x] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
- [x] The Pull Request has an informative and human-readable title
- [x] Changes are limited to a single goal (avoid scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] I confirm that I have read any Contribution guidelines (CONTRIBUTING)
- [x] I confirm that I wrote and/or have the right to submit the contents of my PR, by agreeing to the _Developer Certificate of Origin_, by adding a 'sign-off' to my commits
