### PR TITLE
ci: restrict workflows further

### DIFF
--- a/.conform.yaml
+++ b/.conform.yaml
@@ -17,5 +17,15 @@ policies:
       body:
         required: false
       conventional:
-        types: ["chore","ci", "docs", "perf", "refactor", "style", "test", "release"]
+        types:
+          [
+            "chore",
+            "ci",
+            "docs",
+            "perf",
+            "refactor",
+            "style",
+            "test",
+            "release",
+          ]
         scopes: [".*"]

--- a/.github/workflows/commit.yml
+++ b/.github/workflows/commit.yml
@@ -14,6 +14,11 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ (github.event_name == 'pull_request') && (github.actor != 'dependabot[bot]') }}
     steps:
+      - name: Harden GitHub runner
+        uses: step-security/harden-runner@91182cccc01eb5e619899d80e4e971d6181294a7 #v2.10.1
+        with:
+          egress-policy: audit
+
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 #v4.1.7
         with:
           fetch-depth: 0

--- a/.github/workflows/license.yml
+++ b/.github/workflows/license.yml
@@ -14,6 +14,10 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ (github.event_name == 'pull_request') && (github.actor != 'dependabot[bot]') }}
     steps:
+      - uses: step-security/harden-runner@91182cccc01eb5e619899d80e4e971d6181294a7 #v2.10.1
+        with:
+          egress-policy: audit
+
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 #v4.1.7
         with:
           fetch-depth: 10

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -23,6 +23,11 @@ jobs:
       security-events: write
 
     steps:
+      - name: Harden GitHub runner
+        uses: step-security/harden-runner@91182cccc01eb5e619899d80e4e971d6181294a7 #v2.10.1
+        with:
+          egress-policy: audit
+
       - name: Checkout Code
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 #v4.1.7
         with:

--- a/.github/workflows/lintpubliccode.yml
+++ b/.github/workflows/lintpubliccode.yml
@@ -15,6 +15,11 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ (github.event_name == 'pull_request') && (github.actor != 'dependabot[bot]') }}
     steps:
+      - name: Harden GitHub runner
+        uses: step-security/harden-runner@91182cccc01eb5e619899d80e4e971d6181294a7 #v2.10.1
+        with:
+          egress-policy: audit
+
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 #v4.1.7
       - uses: italia/publiccode-parser-action@3244a5a109ae23f76cb379831abbad32927cad8c # v1.2.0
         with:

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -15,10 +15,17 @@ on: # yamllint disable-line rule:truthy
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   commit:
+    permissions:
+      contents: read
     uses: ./.github/workflows/commit.yml
   license:
+    permissions:
+      contents: read
     uses: ./.github/workflows/license.yml
   lint:
     permissions:
@@ -26,4 +33,6 @@ jobs:
       security-events: write
     uses: ./.github/workflows/lint.yml
   lintpubliccode:
+    permissions:
+      contents: read
     uses: ./.github/workflows/lintpubliccode.yml


### PR DESCRIPTION
Further restricts the CI permissionss

## Checklist

- [x] Changes are limited to a single goal (avoid scope creep)
- [x] I confirm that I have read any Contribution and Development guidelines (CONTRIBUTING and DEVELOPMENT) and are following their suggestions.
- [x] I confirm that I wrote and/or have the right to submit the contents of my Pull Request, by agreeing to the _Developer Certificate of Origin_, (adding a 'sign-off' to my commits).